### PR TITLE
fix bug in reading multiple snapshot files

### DIFF
--- a/readgadget/readgadget.py
+++ b/readgadget/readgadget.py
@@ -126,7 +126,7 @@ def readsnap(snap,data,ptype,**kwargs):
             arr = arr[0::h.nth]
 
         ## put arrays together
-        if i > 0:
+        if N > 0:
             if len(arr) > 0:
                 # return_arr = np.concatenate((return_arr,arr))
                 return_arr[N:N+arr.shape[0]] = arr


### PR DESCRIPTION
There is an error:
```
  File "/home/weiguang/software/pygadgetreader/readgadget/readgadget.py", line 132, in readsnap
    return_arr[N:N+arr.shape[0]] = arr
UnboundLocalError: local variable 'return_arr' referenced before assignment
```
Now it should be fixed﻿
