### PR TITLE
fix float32 overflow when reading temperature units

### DIFF
--- a/readgadget/modules/common.py
+++ b/readgadget/modules/common.py
@@ -95,6 +95,7 @@ def getTfactor(Ne,h):
     """calculate temperature conversion factor including Ne"""
     MeanWeight = (4.0 / (3.0 * H_MASSFRAC + 1.0 + 4.0 * H_MASSFRAC * Ne) * 
                   PROTONMASS)
+    MeanWeight = MeanWeight.astype('float64')
     conversion = (MeanWeight / BOLTZMANN * (GAMMA - 1.0) * 
                   h.UnitEnergy_in_cgs / h.UnitMass_in_g)
     return conversion


### PR DESCRIPTION
When reading temperature with units=1 ElectronAbundance (ne) is also read to calculate the conversion factor. Ne is a float32 numpy array and multiplying with UnitEnergy (e53) causes it to overflow and return NaNs.